### PR TITLE
docs: fix card height

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <div align="center">
   <img src="./images/programming.gif" alt="programming" height="360" width="640">
-  <img height=200 src="https://github-readme-stats.vercel.app/api?username=JamBalaya56562&show_icons=true&theme=tokyonight" alt="profile">
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=JamBalaya56562&layout=compact&theme=tokyonight" alt="top-langs">
+  <img src="https://github-readme-stats.vercel.app/api?username=JamBalaya56562&show_icons=true&theme=tokyonight" alt="profile">
+  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=JamBalaya56562&layout=compact&theme=tokyonight" alt="top-languages">
 </div>
 
 <h2 align="center">ミ★ 𝓚𝓷𝓸𝔀𝓵𝓮𝓭𝓰𝓮 ★彡</h2>


### PR DESCRIPTION
## Summary by Sourcery

Fix GitHub stats cards in README by removing the hardcoded height on the profile card and updating the alt text of the top languages image

Documentation:
- Remove fixed height attribute from the GitHub profile stats card
- Correct the alt text of the top languages stats image from ‘top-langs’ to ‘top-languages’