### PR TITLE
docs: replace Linux and Git badges with OpenTofu badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 [<img src="https://img.shields.io/badge/Python-3776AB?labelColor=000000&logo=python&style=for-the-badge">](https://www.python.org/)
 [<img src="https://img.shields.io/badge/Tailwind%20CSS-06B6D4?labelColor=000000&logo=tailwindcss&style=for-the-badge">](https://tailwindcss.com/)
 [<img src="https://img.shields.io/badge/Nginx-009639?labelColor=000000&logo=nginx&style=for-the-badge">](https://nginx.org/)
+[<img src="https://img.shields.io/badge/Ansible-EE0000?labelColor=000000&logo=ansible&style=for-the-badge">](https://www.redhat.com/en/ansible-collaborative/)
 [<img src="https://img.shields.io/badge/Docker-2496ED?labelColor=000000&logo=docker&style=for-the-badge">](https://www.docker.com/)
-[<img src="https://img.shields.io/badge/Linux-FCC624?labelColor=000000&logo=linux&style=for-the-badge">](https://kernel.org/)
-[<img src="https://img.shields.io/badge/Git-F05032?labelColor=000000&logo=git&style=for-the-badge">](https://git-scm.com/)
+[<img src="https://img.shields.io/badge/OpenTofu-FFDA18?labelColor=000000&logo=opentofu&style=for-the-badge">](https://opentofu.org/)
 
 <h2 align="center">𓂀 𝔸𝕔𝕥𝕚𝕧𝕚𝕥𝕪 𓂀</h2>
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Replace Linux and Git badges in README with an OpenTofu badge and add an Ansible badge to the technology stack list.