### PR TITLE
ci: add stats-card GitHub Actions

### DIFF
--- a/.github/workflows/stats-card.yml
+++ b/.github/workflows/stats-card.yml
@@ -1,0 +1,43 @@
+name: Update README cards
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate stats card
+        uses: readme-tools/github-readme-stats-action@v1
+        with:
+          card: stats
+          options: username=${{ github.repository_owner }}&show_icons=true&theme=tokyonight
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate top languages card
+        uses: readme-tools/github-readme-stats-action@v1
+        with:
+          card: top-langs
+          options: username=${{ github.repository_owner }}&layout=compact&theme=tokyonight
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate pin card
+        uses: readme-tools/github-readme-stats-action@v1
+        with:
+          card: pin
+          options: username=readme-tools&repo=github-readme-stats
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit cards
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add profile/*.svg
+          git commit -m "docs: update README cards" || exit 0
+          git push

--- a/.github/workflows/waka-readme.yml
+++ b/.github/workflows/waka-readme.yml
@@ -1,9 +1,9 @@
-name: Waka Readme
+name: ⏲️ Waka Readme
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   update-readme:
@@ -12,5 +12,6 @@ jobs:
     steps:
       - uses: athul/waka-readme@master
         with:
-          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
           BLOCKS: "⬜🟨🟩"
+          COMMIT_MESSAGE: "docs: update waka-readme graph with new metrics"
+          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}


### PR DESCRIPTION
## Summary by Sourcery

Add scheduled workflows to update README WakaTime graph and generate GitHub stats cards.

CI:
- Adjust Waka Readme workflow naming, triggers, and commit message configuration.
- Introduce a new scheduled stats-card workflow that generates and commits README stats, top languages, and pinned repository SVG cards.