### PR TITLE
ci: change cron time

### DIFF
--- a/.github/workflows/stats-card.yml
+++ b/.github/workflows/stats-card.yml
@@ -1,8 +1,8 @@
-name: Update README cards
+name: 🃏 Update README cards
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 12 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary by Sourcery

Adjust CI workflow schedule and label for updating README stats cards.

CI:
- Change the stats-card workflow cron schedule from midnight to 12:00 UTC.
- Update the workflow display name to include a playing cards emoji.