### PR TITLE
ci: use GraphQL for verified signing commit

### DIFF
--- a/.github/api/createCommitOnBranch.gql
+++ b/.github/api/createCommitOnBranch.gql
@@ -1,0 +1,26 @@
+mutation (
+    $githubRepository: String!,
+    $branchName: String!,
+    $expectedHeadOid: GitObjectID!
+    $commitMessage: String!
+    $files: [FileAddition!]!
+) {
+  createCommitOnBranch(
+    input: {
+    branch:
+    {
+        repositoryNameWithOwner: $githubRepository,
+        branchName: $branchName
+    },
+    message: {headline: $commitMessage},
+    fileChanges: {
+        additions: $files
+    }
+    expectedHeadOid: $expectedHeadOid
+    }
+  ){
+    commit {
+    url
+    }
+  }
+}

--- a/.github/workflows/stats-card.yml
+++ b/.github/workflows/stats-card.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      checks: write
+      statuses: write
       contents: write
     steps:
       - uses: actions/checkout@v6
@@ -35,9 +37,16 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit cards
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add profile/*.svg
-          git commit -m "docs: update README cards" || exit 0
-          git push
+          gh api graphql \
+          -F githubRepository=$REPO \
+          -F branchName="main" \
+          -F expectedHeadOid=$(git rev-parse HEAD) \
+          -F commitMessage="docs: update README cards" \
+          -F files[][path]="profile/stats.svg" -F files[][contents]=$(base64 -w0 profile/stats.svg) \
+          -F files[][path]="profile/top-langs.svg" -F files[][contents]=$(base64 -w0 profile/top-langs.svg) \
+          -F files[][path]="profile/pin.svg" -F files[][contents]=$(base64 -w0 profile/pin.svg) \
+          -F "query=@.github/api/createCommitOnBranch.gql"


### PR DESCRIPTION
## Summary by Sourcery

Use GitHub's GraphQL API to create verified commits for updated stats card files in the stats-card workflow.

CI:
- Grant additional checks and statuses write permissions to the stats-card workflow to support GraphQL-based committing.

Chores:
- Replace direct git commit/push of generated SVG cards with a GraphQL-based commit-on-branch operation using the GitHub CLI and a new createCommitOnBranch.gql query file.