### PR TITLE
ci: update branch name in stats-card workflow

### DIFF
--- a/.github/workflows/stats-card.yml
+++ b/.github/workflows/stats-card.yml
@@ -34,12 +34,13 @@ jobs:
 
       - name: 💾 Commit cards
         env:
+          BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           gh api graphql \
           -F githubRepository=$REPO \
-          -F branchName="main" \
+          -F branchName=$BRANCH \
           -F expectedHeadOid=$(git rev-parse HEAD) \
           -F commitMessage="docs: update README cards" \
           -F files[][path]="profile/stats.svg" -F files[][contents]=$(base64 -w0 profile/stats.svg) \


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use the repository default branch in the stats-card workflow GraphQL call instead of assuming the branch is named 'main'.